### PR TITLE
Playback enhancements

### DIFF
--- a/crates/media/src/ffmpeg_backend.rs
+++ b/crates/media/src/ffmpeg_backend.rs
@@ -116,11 +116,12 @@ pub fn transcode_bytes_for_browser(
     transcode_file_to_bytes(&input_path, FfmpegOutput::Playback(format), None)
 }
 
-pub fn render_flac_48k_hls(
+pub fn render_flac_hls(
     path: &Path,
     output_dir: &Path,
     start_ms: i64,
     end_ms: Option<i64>,
+    sample_rate: u32,
 ) -> Result<()> {
     init_ffmpeg()?;
     fs::create_dir_all(output_dir)
@@ -143,7 +144,7 @@ pub fn render_flac_48k_hls(
         &mut ictx,
         &mut octx,
         &playlist_path,
-        FfmpegOutput::HlsFlac48k,
+        FfmpegOutput::HlsFlac { sample_rate },
         Some(FilterRange::Time(TimeRange {
             start_ms: start_ms.max(0),
             end_ms,
@@ -176,7 +177,7 @@ enum FilterRange {
 enum FfmpegOutput {
     FlacSourceRate,
     Playback(PlaybackTranscodeFormat),
-    HlsFlac48k,
+    HlsFlac { sample_rate: u32 },
 }
 
 impl FfmpegOutput {
@@ -184,7 +185,7 @@ impl FfmpegOutput {
         match self {
             Self::FlacSourceRate => "audio/flac",
             Self::Playback(format) => format.mime(),
-            Self::HlsFlac48k => "application/vnd.apple.mpegurl",
+            Self::HlsFlac { .. } => "application/vnd.apple.mpegurl",
         }
     }
 
@@ -192,46 +193,48 @@ impl FfmpegOutput {
         match self {
             Self::FlacSourceRate => "flac",
             Self::Playback(format) => format.extension(),
-            Self::HlsFlac48k => "m3u8",
+            Self::HlsFlac { .. } => "m3u8",
         }
     }
 
     fn container_format(self) -> &'static str {
         match self {
-            Self::FlacSourceRate | Self::Playback(PlaybackTranscodeFormat::Flac48k) => "flac",
-            Self::Playback(PlaybackTranscodeFormat::Opus256k) => "ogg",
-            Self::HlsFlac48k => "hls",
+            Self::FlacSourceRate | Self::Playback(PlaybackTranscodeFormat::Flac { .. }) => "flac",
+            Self::Playback(PlaybackTranscodeFormat::Opus { .. }) => "ogg",
+            Self::HlsFlac { .. } => "hls",
         }
     }
 
     fn quality(self) -> CueRenderQuality {
         match self {
             Self::FlacSourceRate => CueRenderQuality::Lossless,
-            Self::Playback(PlaybackTranscodeFormat::Opus256k) => CueRenderQuality::Lossy,
-            Self::Playback(PlaybackTranscodeFormat::Flac48k) => CueRenderQuality::Lossless,
-            Self::HlsFlac48k => CueRenderQuality::Lossless,
+            Self::Playback(PlaybackTranscodeFormat::Opus { .. }) => CueRenderQuality::Lossy,
+            Self::Playback(PlaybackTranscodeFormat::Flac { .. }) => CueRenderQuality::Lossless,
+            Self::HlsFlac { .. } => CueRenderQuality::Lossless,
         }
     }
 
     fn encoder_name(self) -> Option<&'static str> {
         match self {
             Self::FlacSourceRate
-            | Self::Playback(PlaybackTranscodeFormat::Flac48k)
-            | Self::HlsFlac48k => Some("flac"),
-            Self::Playback(PlaybackTranscodeFormat::Opus256k) => Some("libopus"),
+            | Self::Playback(PlaybackTranscodeFormat::Flac { .. })
+            | Self::HlsFlac { .. } => Some("flac"),
+            Self::Playback(PlaybackTranscodeFormat::Opus { .. }) => Some("libopus"),
         }
     }
 
     fn target_rate(self, source_rate: u32) -> u32 {
         match self {
             Self::FlacSourceRate => source_rate,
-            Self::Playback(_) | Self::HlsFlac48k => 48_000,
+            Self::Playback(PlaybackTranscodeFormat::Opus { .. }) => 48_000,
+            Self::Playback(PlaybackTranscodeFormat::Flac { sample_rate })
+            | Self::HlsFlac { sample_rate } => sample_rate,
         }
     }
 
     fn bit_rate(self) -> Option<usize> {
         match self {
-            Self::Playback(PlaybackTranscodeFormat::Opus256k) => Some(256_000),
+            Self::Playback(PlaybackTranscodeFormat::Opus { bit_rate }) => Some(bit_rate),
             _ => None,
         }
     }
@@ -239,7 +242,7 @@ impl FfmpegOutput {
     fn is_flac(self) -> bool {
         matches!(
             self,
-            Self::FlacSourceRate | Self::Playback(PlaybackTranscodeFormat::Flac48k)
+            Self::FlacSourceRate | Self::Playback(PlaybackTranscodeFormat::Flac { .. })
         )
     }
 }
@@ -808,11 +811,21 @@ mod tests {
         let source = dir.path().join("source.wav");
         write_test_wav(&source, 5, 44_100);
 
-        let opus = transcode_file_for_browser(&source, PlaybackTranscodeFormat::Opus256k).unwrap();
+        let opus = transcode_file_for_browser(
+            &source,
+            PlaybackTranscodeFormat::Opus { bit_rate: 256_000 },
+        )
+        .unwrap();
         assert!(opus.bytes.len() > 1024);
         assert_duration_ms("opus", &dir.path().join("out.opus"), &opus.bytes, 4_500);
 
-        let flac = transcode_file_for_browser(&source, PlaybackTranscodeFormat::Flac48k).unwrap();
+        let flac = transcode_file_for_browser(
+            &source,
+            PlaybackTranscodeFormat::Flac {
+                sample_rate: 48_000,
+            },
+        )
+        .unwrap();
         assert!(flac.bytes.len() > 1024);
         assert_duration_ms("flac", &dir.path().join("out.flac"), &flac.bytes, 4_500);
     }
@@ -830,7 +843,7 @@ mod tests {
         let handle = std::thread::spawn(move || {
             transcode_file_range_for_browser_to_fd(
                 &source_for_thread,
-                PlaybackTranscodeFormat::Opus256k,
+                PlaybackTranscodeFormat::Opus { bit_rate: 256_000 },
                 2_000,
                 Some(4_000),
                 output_fd,
@@ -850,13 +863,13 @@ mod tests {
     }
 
     #[test]
-    fn renders_flac_48k_hls_vod_playlist() {
+    fn renders_flac_hls_vod_playlist_at_requested_sample_rate() {
         let dir = tempfile::tempdir().unwrap();
         let source = dir.path().join("source.wav");
         let hls_dir = dir.path().join("hls");
         write_test_wav(&source, 5, 96_000);
 
-        render_flac_48k_hls(&source, &hls_dir, 0, None).unwrap();
+        render_flac_hls(&source, &hls_dir, 0, None, 44_100).unwrap();
 
         let playlist_path = hls_dir.join(FLAC_HLS_PLAYLIST_FILE);
         let playlist = fs::read_to_string(&playlist_path).unwrap();
@@ -872,12 +885,12 @@ mod tests {
         let context = ffmpeg::codec::context::Context::from_parameters(input.parameters()).unwrap();
         let mut decoder = context.decoder().audio().unwrap();
         decoder.set_parameters(input.parameters()).unwrap();
-        assert_eq!(decoder.rate(), 48_000);
+        assert_eq!(decoder.rate(), 44_100);
         assert_duration_ms("flac hls", &playlist_path, &[], 4_500);
     }
 
     #[test]
-    fn renders_flac_48k_hls_range_from_zero_media_time() {
+    fn renders_flac_hls_range_from_zero_media_time() {
         let dir = tempfile::tempdir().unwrap();
         let source_wav = dir.path().join("source.wav");
         let source = dir.path().join("source.flac");
@@ -885,7 +898,7 @@ mod tests {
         write_test_wav(&source_wav, 12, 96_000);
         transcode_file_to_path(&source_wav, &source, FfmpegOutput::FlacSourceRate, None).unwrap();
 
-        render_flac_48k_hls(&source, &hls_dir, 5_000, Some(10_000)).unwrap();
+        render_flac_hls(&source, &hls_dir, 5_000, Some(10_000), 48_000).unwrap();
 
         let first_segment = fs::read(hls_dir.join("segment_00000.m4s")).unwrap();
         assert_eq!(find_tfdt_base_media_decode_time(&first_segment), Some(0));

--- a/crates/media/src/render.rs
+++ b/crates/media/src/render.rs
@@ -15,8 +15,8 @@ pub enum CueRenderQuality {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PlaybackTranscodeFormat {
-    Opus256k,
-    Flac48k,
+    Opus { bit_rate: usize },
+    Flac { sample_rate: u32 },
 }
 
 pub const FLAC_HLS_PLAYLIST_FILE: &str = "playlist.m3u8";
@@ -29,15 +29,15 @@ pub const FLAC_HLS_SEGMENT_SECONDS: f64 = 2.0;
 impl PlaybackTranscodeFormat {
     pub fn mime(self) -> &'static str {
         match self {
-            Self::Opus256k => "audio/ogg; codecs=opus",
-            Self::Flac48k => "audio/flac",
+            Self::Opus { .. } => "audio/ogg; codecs=opus",
+            Self::Flac { .. } => "audio/flac",
         }
     }
 
     pub fn extension(self) -> &'static str {
         match self {
-            Self::Opus256k => "opus",
-            Self::Flac48k => "flac",
+            Self::Opus { .. } => "opus",
+            Self::Flac { .. } => "flac",
         }
     }
 }

--- a/crates/media/src/transcode.rs
+++ b/crates/media/src/transcode.rs
@@ -40,11 +40,12 @@ pub fn transcode_rendered_cue_for_browser(
     ffmpeg_backend::transcode_bytes_for_browser(rendered.bytes, rendered.extension, format)
 }
 
-pub fn render_flac_48k_hls(
+pub fn render_flac_hls(
     path: &Path,
     output_dir: &Path,
     start_ms: i64,
     end_ms: Option<i64>,
+    sample_rate: u32,
 ) -> Result<()> {
-    ffmpeg_backend::render_flac_48k_hls(path, output_dir, start_ms, end_ms)
+    ffmpeg_backend::render_flac_hls(path, output_dir, start_ms, end_ms, sample_rate)
 }

--- a/crates/server/src/application/playback.rs
+++ b/crates/server/src/application/playback.rs
@@ -1,4 +1,4 @@
-use crate::domain::{BrowserPlaybackFormat, PlaybackSource, TrackId};
+use crate::domain::{BrowserPlaybackSettings, PlaybackSource, TrackId};
 use anyhow::Result;
 use futures::future::BoxFuture;
 use std::path::PathBuf;
@@ -33,7 +33,7 @@ pub struct RenderedAudio {
 #[derive(Debug, Clone)]
 pub struct BrowserAudioRequest {
     pub path: PathBuf,
-    pub format: BrowserPlaybackFormat,
+    pub playback: BrowserPlaybackSettings,
     pub start_ms: i64,
     pub end_ms: Option<i64>,
 }
@@ -44,12 +44,13 @@ pub struct HlsRenderRequest {
     pub output_dir: PathBuf,
     pub start_ms: i64,
     pub end_ms: Option<i64>,
+    pub flac_sample_rate: u32,
 }
 
 pub trait PlaybackMedia: Send + Sync {
     fn passthrough_renderer(&self) -> &'static str;
 
-    fn browser_audio_format(&self, format: BrowserPlaybackFormat) -> BrowserAudioFormat;
+    fn browser_audio_format(&self, playback: BrowserPlaybackSettings) -> BrowserAudioFormat;
 
     fn is_playable_renderer(&self, renderer_id: Option<&str>) -> bool;
 
@@ -76,7 +77,7 @@ pub trait PlaybackMedia: Send + Sync {
 #[derive(Debug, Clone)]
 pub struct BrowserStreamPlan {
     pub source: PlaybackSource,
-    pub format: BrowserPlaybackFormat,
+    pub playback: BrowserPlaybackSettings,
     pub absolute_start_ms: i64,
     pub end_ms: Option<i64>,
     pub buffered: bool,
@@ -104,14 +105,14 @@ pub async fn track_render_source(
 
 pub fn browser_stream_plan(
     source: PlaybackSource,
-    format: BrowserPlaybackFormat,
+    playback: BrowserPlaybackSettings,
     requested_start_ms: i64,
     buffered: bool,
 ) -> BrowserStreamPlan {
     let (absolute_start_ms, end_ms) = browser_stream_time_range(&source, requested_start_ms);
     BrowserStreamPlan {
         source,
-        format,
+        playback,
         absolute_start_ms,
         end_ms,
         buffered,
@@ -151,7 +152,7 @@ mod tests {
     #[test]
     fn browser_stream_plan_clamps_relative_start_to_track_end() {
         let source = playback_source(Some(10_000), Some(20_000));
-        let plan = browser_stream_plan(source, BrowserPlaybackFormat::Opus256k, 50_000, false);
+        let plan = browser_stream_plan(source, BrowserPlaybackSettings::default(), 50_000, false);
 
         assert_eq!(plan.absolute_start_ms, 19_999);
         assert_eq!(plan.end_ms, Some(20_000));

--- a/crates/server/src/application/settings.rs
+++ b/crates/server/src/application/settings.rs
@@ -16,5 +16,5 @@ pub async fn update_settings(
     repository: &impl SettingsRepository,
     req: UpdateAppSettings,
 ) -> Result<AppSettings> {
-    repository.update_settings(req).await
+    repository.update_settings(req.normalized()).await
 }

--- a/crates/server/src/domain.rs
+++ b/crates/server/src/domain.rs
@@ -327,13 +327,41 @@ impl ArtworkSource {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, o2o)]
 #[map_owned(api::BrowserPlaybackFormat)]
 pub enum BrowserPlaybackFormat {
-    Opus256k,
-    Flac48k,
+    Opus,
+    Flac,
 }
 
 impl Default for BrowserPlaybackFormat {
     fn default() -> Self {
-        Self::Opus256k
+        Self::Opus
+    }
+}
+
+#[derive(Debug, Clone, Copy, o2o)]
+#[map_owned(api::BrowserPlaybackSettings)]
+pub struct BrowserPlaybackSettings {
+    #[map(~.into())]
+    pub format: BrowserPlaybackFormat,
+    pub opus_bitrate: i64,
+    pub flac_sample_rate: i64,
+}
+
+impl Default for BrowserPlaybackSettings {
+    fn default() -> Self {
+        Self {
+            format: BrowserPlaybackFormat::default(),
+            opus_bitrate: api::DEFAULT_BROWSER_PLAYBACK_OPUS_BITRATE,
+            flac_sample_rate: api::DEFAULT_BROWSER_PLAYBACK_FLAC_SAMPLE_RATE,
+        }
+    }
+}
+
+impl BrowserPlaybackSettings {
+    pub fn normalized(mut self) -> Self {
+        self.opus_bitrate = api::normalize_browser_playback_opus_bitrate(self.opus_bitrate);
+        self.flac_sample_rate =
+            api::normalize_browser_playback_flac_sample_rate(self.flac_sample_rate);
+        self
     }
 }
 
@@ -341,14 +369,21 @@ impl Default for BrowserPlaybackFormat {
 #[map_owned(api::AppSettings)]
 pub struct AppSettings {
     #[map(~.into())]
-    pub browser_playback_format: BrowserPlaybackFormat,
+    pub browser_playback: BrowserPlaybackSettings,
 }
 
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
-            browser_playback_format: BrowserPlaybackFormat::default(),
+            browser_playback: BrowserPlaybackSettings::default(),
         }
+    }
+}
+
+impl AppSettings {
+    pub fn normalized(mut self) -> Self {
+        self.browser_playback = self.browser_playback.normalized();
+        self
     }
 }
 
@@ -356,7 +391,14 @@ impl Default for AppSettings {
 #[map_owned(api::UpdateAppSettingsRequest)]
 pub struct UpdateAppSettings {
     #[map(~.into())]
-    pub browser_playback_format: BrowserPlaybackFormat,
+    pub browser_playback: BrowserPlaybackSettings,
+}
+
+impl UpdateAppSettings {
+    pub fn normalized(mut self) -> Self {
+        self.browser_playback = self.browser_playback.normalized();
+        self
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/server/src/infra/media.rs
+++ b/crates/server/src/infra/media.rs
@@ -6,7 +6,7 @@ use crate::application::scan::{
     CueSheetReader, CueTrack, DiscoveredAudioFile, DiscoveredCueFile, DiscoveredLibraryFiles,
     EmbeddedPictureInfo, LibraryFileDiscovery,
 };
-use crate::domain::{BrowserPlaybackFormat, PlaybackSource};
+use crate::domain::{BrowserPlaybackFormat, BrowserPlaybackSettings, PlaybackSource};
 use anyhow::Result;
 use easy_musiclib_media::cue as media_cue;
 use easy_musiclib_media::cue_render;
@@ -107,8 +107,8 @@ impl PlaybackMedia for FfmpegPlaybackMedia {
         cue_render::PASSTHROUGH_RENDERER
     }
 
-    fn browser_audio_format(&self, format: BrowserPlaybackFormat) -> BrowserAudioFormat {
-        let format = media_playback_format(format);
+    fn browser_audio_format(&self, playback: BrowserPlaybackSettings) -> BrowserAudioFormat {
+        let format = media_playback_format(playback);
         BrowserAudioFormat {
             mime: format.mime(),
             extension: format.extension(),
@@ -159,7 +159,7 @@ impl PlaybackMedia for FfmpegPlaybackMedia {
         request: BrowserAudioRequest,
     ) -> BoxFuture<'static, Result<RenderedAudio>> {
         async move {
-            let format = media_playback_format(request.format);
+            let format = media_playback_format(request.playback);
             let rendered = tokio::task::spawn_blocking(move || {
                 transcode::transcode_file_range_for_browser(
                     &request.path,
@@ -185,7 +185,7 @@ impl PlaybackMedia for FfmpegPlaybackMedia {
         output_fd: RawFd,
     ) -> BoxFuture<'static, Result<()>> {
         async move {
-            let format = media_playback_format(request.format);
+            let format = media_playback_format(request.playback);
             tokio::task::spawn_blocking(move || {
                 transcode::transcode_file_range_for_browser_to_fd(
                     &request.path,
@@ -204,11 +204,12 @@ impl PlaybackMedia for FfmpegPlaybackMedia {
     fn render_hls(&self, request: HlsRenderRequest) -> BoxFuture<'static, Result<()>> {
         async move {
             tokio::task::spawn_blocking(move || {
-                transcode::render_flac_48k_hls(
+                transcode::render_flac_hls(
                     &request.path,
                     &request.output_dir,
                     request.start_ms,
                     request.end_ms,
+                    request.flac_sample_rate,
                 )
             })
             .await??;
@@ -218,10 +219,15 @@ impl PlaybackMedia for FfmpegPlaybackMedia {
     }
 }
 
-fn media_playback_format(format: BrowserPlaybackFormat) -> PlaybackTranscodeFormat {
-    match format {
-        BrowserPlaybackFormat::Opus256k => PlaybackTranscodeFormat::Opus256k,
-        BrowserPlaybackFormat::Flac48k => PlaybackTranscodeFormat::Flac48k,
+fn media_playback_format(playback: BrowserPlaybackSettings) -> PlaybackTranscodeFormat {
+    let playback = playback.normalized();
+    match playback.format {
+        BrowserPlaybackFormat::Opus => PlaybackTranscodeFormat::Opus {
+            bit_rate: playback.opus_bitrate as usize,
+        },
+        BrowserPlaybackFormat::Flac => PlaybackTranscodeFormat::Flac {
+            sample_rate: playback.flac_sample_rate as u32,
+        },
     }
 }
 

--- a/crates/server/src/infra/sqlite/schema.rs
+++ b/crates/server/src/infra/sqlite/schema.rs
@@ -78,6 +78,35 @@ async fn migrate_db(pool: &SqlitePool) -> Result<()> {
     .execute(pool)
     .await?;
 
+    reset_legacy_playback_settings(pool).await?;
+
+    Ok(())
+}
+
+async fn reset_legacy_playback_settings(pool: &SqlitePool) -> Result<()> {
+    let marker = "__app_settings_reset_for_browser_playback_v1";
+    let reset_done = sqlx::query("SELECT 1 FROM app_settings WHERE key = ?")
+        .bind(marker)
+        .fetch_optional(pool)
+        .await?
+        .is_some();
+    if reset_done {
+        return Ok(());
+    }
+
+    let now = chrono::Utc::now().timestamp_millis();
+    sqlx::query("DELETE FROM app_settings")
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO app_settings (key, value_json, updated_at)
+         VALUES (?, ?, ?)",
+    )
+    .bind(marker)
+    .bind("true")
+    .bind(now)
+    .execute(pool)
+    .await?;
     Ok(())
 }
 

--- a/crates/server/src/infra/sqlite/settings.rs
+++ b/crates/server/src/infra/sqlite/settings.rs
@@ -1,11 +1,16 @@
 use crate::application::settings::SettingsRepository;
-use crate::domain::{AppSettings, BrowserPlaybackFormat, UpdateAppSettings};
+use crate::domain::{
+    AppSettings, BrowserPlaybackFormat, BrowserPlaybackSettings, UpdateAppSettings,
+};
 use anyhow::Result;
+use easy_musiclib_shared::{
+    DEFAULT_BROWSER_PLAYBACK_FLAC_SAMPLE_RATE, DEFAULT_BROWSER_PLAYBACK_OPUS_BITRATE,
+};
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use sqlx::{Row, SqlitePool};
 
-const BROWSER_PLAYBACK_FORMAT_SETTING: &str = "browser_playback_format";
+const BROWSER_PLAYBACK_SETTING: &str = "browser_playback";
 
 #[derive(Clone)]
 pub struct SqliteSettingsRepository {
@@ -30,19 +35,21 @@ impl SettingsRepository for SqliteSettingsRepository {
 
 async fn app_settings(pool: &SqlitePool) -> Result<AppSettings> {
     Ok(AppSettings {
-        browser_playback_format: setting_json::<StoredBrowserPlaybackFormat>(
+        browser_playback: setting_json::<StoredBrowserPlaybackSettings>(
             pool,
-            BROWSER_PLAYBACK_FORMAT_SETTING,
+            BROWSER_PLAYBACK_SETTING,
         )
         .await?
         .map(Into::into)
         .unwrap_or_default(),
-    })
+    }
+    .normalized())
 }
 
 async fn update_app_settings(pool: &SqlitePool, req: UpdateAppSettings) -> Result<AppSettings> {
-    let format: StoredBrowserPlaybackFormat = req.browser_playback_format.into();
-    put_setting_json(pool, BROWSER_PLAYBACK_FORMAT_SETTING, &format).await?;
+    let req = req.normalized();
+    let playback: StoredBrowserPlaybackSettings = req.browser_playback.into();
+    put_setting_json(pool, BROWSER_PLAYBACK_SETTING, &playback).await?;
     app_settings(pool).await
 }
 
@@ -84,17 +91,71 @@ fn now_ms() -> i64 {
 
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 enum StoredBrowserPlaybackFormat {
-    #[serde(rename = "opus_256k")]
-    Opus256k,
-    #[serde(rename = "flac_48k")]
-    Flac48k,
+    #[serde(rename = "opus")]
+    Opus,
+    #[serde(rename = "flac")]
+    Flac,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+struct StoredBrowserPlaybackSettings {
+    #[serde(default)]
+    format: StoredBrowserPlaybackFormat,
+    #[serde(default = "default_opus_bitrate")]
+    opus_bitrate: i64,
+    #[serde(default = "default_flac_sample_rate")]
+    flac_sample_rate: i64,
+}
+
+impl Default for StoredBrowserPlaybackSettings {
+    fn default() -> Self {
+        Self {
+            format: StoredBrowserPlaybackFormat::default(),
+            opus_bitrate: DEFAULT_BROWSER_PLAYBACK_OPUS_BITRATE,
+            flac_sample_rate: DEFAULT_BROWSER_PLAYBACK_FLAC_SAMPLE_RATE,
+        }
+    }
+}
+
+fn default_opus_bitrate() -> i64 {
+    DEFAULT_BROWSER_PLAYBACK_OPUS_BITRATE
+}
+
+fn default_flac_sample_rate() -> i64 {
+    DEFAULT_BROWSER_PLAYBACK_FLAC_SAMPLE_RATE
+}
+
+impl Default for StoredBrowserPlaybackFormat {
+    fn default() -> Self {
+        Self::Opus
+    }
+}
+
+impl From<StoredBrowserPlaybackSettings> for BrowserPlaybackSettings {
+    fn from(value: StoredBrowserPlaybackSettings) -> Self {
+        Self {
+            format: value.format.into(),
+            opus_bitrate: value.opus_bitrate,
+            flac_sample_rate: value.flac_sample_rate,
+        }
+    }
+}
+
+impl From<BrowserPlaybackSettings> for StoredBrowserPlaybackSettings {
+    fn from(value: BrowserPlaybackSettings) -> Self {
+        Self {
+            format: value.format.into(),
+            opus_bitrate: value.opus_bitrate,
+            flac_sample_rate: value.flac_sample_rate,
+        }
+    }
 }
 
 impl From<StoredBrowserPlaybackFormat> for BrowserPlaybackFormat {
     fn from(value: StoredBrowserPlaybackFormat) -> Self {
         match value {
-            StoredBrowserPlaybackFormat::Opus256k => Self::Opus256k,
-            StoredBrowserPlaybackFormat::Flac48k => Self::Flac48k,
+            StoredBrowserPlaybackFormat::Opus => Self::Opus,
+            StoredBrowserPlaybackFormat::Flac => Self::Flac,
         }
     }
 }
@@ -102,8 +163,8 @@ impl From<StoredBrowserPlaybackFormat> for BrowserPlaybackFormat {
 impl From<BrowserPlaybackFormat> for StoredBrowserPlaybackFormat {
     fn from(value: BrowserPlaybackFormat) -> Self {
         match value {
-            BrowserPlaybackFormat::Opus256k => Self::Opus256k,
-            BrowserPlaybackFormat::Flac48k => Self::Flac48k,
+            BrowserPlaybackFormat::Opus => Self::Opus,
+            BrowserPlaybackFormat::Flac => Self::Flac,
         }
     }
 }

--- a/crates/server/src/services/hls_cache.rs
+++ b/crates/server/src/services/hls_cache.rs
@@ -171,7 +171,7 @@ where
 pub async fn wait_for_hls_file(path: &Path, timeout: Duration) -> ApiResult<()> {
     let deadline = Instant::now() + timeout;
     loop {
-        if tokio::fs::metadata(path).await.is_ok() {
+        if hls_file_ready(path).await {
             return Ok(());
         }
         if Instant::now() >= deadline {
@@ -179,6 +179,57 @@ pub async fn wait_for_hls_file(path: &Path, timeout: Duration) -> ApiResult<()> 
         }
         sleep(Duration::from_millis(50)).await;
     }
+}
+
+pub async fn wait_for_hls_playlist_start(cache_dir: &Path, path: &Path) -> ApiResult<()> {
+    let deadline = Instant::now() + hls_file_timeout(HLS_PLAYLIST_FILE);
+    loop {
+        if let Ok(playlist) = tokio::fs::read_to_string(path).await {
+            if let Some(files) = hls_startup_files(&playlist) {
+                let init_ready = hls_file_ready(&cache_dir.join(&files.init_file)).await;
+                let segment_ready = hls_file_ready(&cache_dir.join(&files.segment_file)).await;
+                if init_ready && segment_ready {
+                    return Ok(());
+                }
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(AppError::not_found("HLS playlist is not ready"));
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn hls_file_ready(path: &Path) -> bool {
+    tokio::fs::metadata(path)
+        .await
+        .map(|metadata| metadata.is_file() && metadata.len() > 0)
+        .unwrap_or(false)
+}
+
+struct HlsStartupFiles {
+    init_file: String,
+    segment_file: String,
+}
+
+fn hls_startup_files(playlist: &str) -> Option<HlsStartupFiles> {
+    let init_file = playlist.lines().find_map(hls_map_uri)?.to_owned();
+    let segment_file = playlist
+        .lines()
+        .map(str::trim)
+        .find(|line| is_hls_segment_file(line))?
+        .to_owned();
+    Some(HlsStartupFiles {
+        init_file,
+        segment_file,
+    })
+}
+
+fn hls_map_uri(line: &str) -> Option<&str> {
+    let attrs = line.trim().strip_prefix("#EXT-X-MAP:")?;
+    let uri_start = attrs.find("URI=\"")? + "URI=\"".len();
+    let uri = &attrs[uri_start..];
+    uri.split('"').next().filter(|value| *value == HLS_INIT_FILE)
 }
 
 fn hls_cache_root() -> PathBuf {
@@ -315,5 +366,55 @@ mod tests {
         let playlist = "#EXTM3U\n#EXT-X-VERSION:7\n#EXT-X-START:TIME-OFFSET=0.000,PRECISE=YES\n#EXT-X-PLAYLIST-TYPE:VOD\n";
 
         assert_eq!(hls_playlist_for_playback(playlist), playlist);
+    }
+
+    #[test]
+    fn hls_startup_files_requires_init_and_first_segment() {
+        let playlist = "#EXTM3U\n#EXT-X-VERSION:7\n#EXT-X-MAP:URI=\"init.mp4\"\n";
+
+        assert!(hls_startup_files(playlist).is_none());
+    }
+
+    #[test]
+    fn hls_startup_files_parses_init_and_first_segment() {
+        let playlist = "#EXTM3U\n#EXT-X-VERSION:7\n#EXT-X-MAP:BYTERANGE=\"12@0\",URI=\"init.mp4\"\n#EXTINF:2.000000,\nsegment_00000.m4s\n#EXTINF:2.000000,\nsegment_00001.m4s\n";
+
+        let files = hls_startup_files(playlist).expect("startup files");
+
+        assert_eq!(files.init_file, HLS_INIT_FILE);
+        assert_eq!(files.segment_file, "segment_00000.m4s");
+    }
+
+    #[tokio::test]
+    async fn wait_for_hls_playlist_start_waits_for_startup_media() {
+        let dir = tempfile::tempdir().unwrap();
+        let playlist_path = dir.path().join(HLS_PLAYLIST_FILE);
+        tokio::fs::write(
+            &playlist_path,
+            "#EXTM3U\n#EXT-X-VERSION:7\n#EXT-X-MAP:URI=\"init.mp4\"\n#EXTINF:2.000000,\nsegment_00000.m4s\n",
+        )
+        .await
+        .unwrap();
+
+        let wait = wait_for_hls_playlist_start(dir.path(), &playlist_path);
+        tokio::pin!(wait);
+
+        tokio::select! {
+            result = &mut wait => panic!("playlist became ready too early: {result:?}"),
+            _ = sleep(Duration::from_millis(120)) => {}
+        }
+
+        tokio::fs::write(dir.path().join(HLS_INIT_FILE), b"init")
+            .await
+            .unwrap();
+        tokio::select! {
+            result = &mut wait => panic!("playlist became ready without first segment: {result:?}"),
+            _ = sleep(Duration::from_millis(120)) => {}
+        }
+
+        tokio::fs::write(dir.path().join("segment_00000.m4s"), b"segment")
+            .await
+            .unwrap();
+        wait.await.unwrap();
     }
 }

--- a/crates/server/src/services/hls_cache.rs
+++ b/crates/server/src/services/hls_cache.rs
@@ -26,7 +26,11 @@ pub async fn clear_hls_cache() -> ApiResult<HlsCacheClearResponse> {
     Ok(summary)
 }
 
-pub async fn hls_cache_dir(track_id: TrackId, source: &PlaybackSource) -> ApiResult<PathBuf> {
+pub async fn hls_cache_dir(
+    track_id: TrackId,
+    source: &PlaybackSource,
+    flac_sample_rate: i64,
+) -> ApiResult<PathBuf> {
     let metadata = tokio::fs::metadata(&source.path).await?;
     let modified = metadata
         .modified()
@@ -35,7 +39,8 @@ pub async fn hls_cache_dir(track_id: TrackId, source: &PlaybackSource) -> ApiRes
         .map(|duration| duration.as_millis())
         .unwrap_or(0);
     let mut hasher = Sha256::new();
-    hasher.update(b"flac-48k-fmp4-hls-v1");
+    hasher.update(b"flac-fmp4-hls-v2");
+    hasher.update(flac_sample_rate.to_le_bytes());
     hasher.update(track_id.raw().to_le_bytes());
     hasher.update(source.path.as_bytes());
     hasher.update(source.renderer.as_bytes());
@@ -103,6 +108,7 @@ pub async fn ensure_hls_generation<M>(
     playback_media: M,
     source: &PlaybackSource,
     cache_dir: &Path,
+    flac_sample_rate: i64,
 ) -> ApiResult<()>
 where
     M: PlaybackMedia + Clone + Send + Sync + 'static,
@@ -144,6 +150,7 @@ where
                     output_dir: cache_dir.clone(),
                     start_ms,
                     end_ms,
+                    flac_sample_rate: flac_sample_rate as u32,
                 })
                 .await?;
             tokio::fs::write(hls_complete_path(&cache_dir), b"ok")
@@ -229,7 +236,9 @@ fn hls_map_uri(line: &str) -> Option<&str> {
     let attrs = line.trim().strip_prefix("#EXT-X-MAP:")?;
     let uri_start = attrs.find("URI=\"")? + "URI=\"".len();
     let uri = &attrs[uri_start..];
-    uri.split('"').next().filter(|value| *value == HLS_INIT_FILE)
+    uri.split('"')
+        .next()
+        .filter(|value| *value == HLS_INIT_FILE)
 }
 
 fn hls_cache_root() -> PathBuf {

--- a/crates/server/src/services/playback.rs
+++ b/crates/server/src/services/playback.rs
@@ -3,7 +3,7 @@ use crate::application::playback::{
     HLS_PLAYLIST_FILE, HLS_PLAYLIST_MIME, PlaybackMedia,
 };
 use crate::application::settings as settings_app;
-use crate::domain::{BrowserPlaybackFormat, PlaybackSource};
+use crate::domain::{BrowserPlaybackSettings, PlaybackSource};
 use crate::http::responses::{audio_bytes_response, ranged_file_response};
 use crate::services::{hls_cache, track_duration};
 use crate::{ApiResult, AppError, AppState};
@@ -40,7 +40,7 @@ pub async fn stream_track_response(
         source,
         settings_app::get_settings(&state.repositories.settings)
             .await?
-            .browser_playback_format,
+            .browser_playback,
         requested_start_ms,
         buffered,
     );
@@ -62,10 +62,18 @@ pub async fn stream_track_hls_file_response(
     {
         return Err(AppError::bad_request("track is not playable"));
     }
-    let cache_dir = hls_cache::hls_cache_dir(id, &source).await?;
+    let playback = settings_app::get_settings(&state.repositories.settings)
+        .await?
+        .browser_playback;
+    let cache_dir = hls_cache::hls_cache_dir(id, &source, playback.flac_sample_rate).await?;
     let path = hls_cache::hls_file_path(&cache_dir, &file)?;
-    hls_cache::ensure_hls_generation(state.services.playback_media.clone(), &source, &cache_dir)
-        .await?;
+    hls_cache::ensure_hls_generation(
+        state.services.playback_media.clone(),
+        &source,
+        &cache_dir,
+        playback.flac_sample_rate,
+    )
+    .await?;
     let mime = hls_file_mime(&file)?;
     if file == HLS_PLAYLIST_FILE {
         hls_cache::wait_for_hls_playlist_start(&cache_dir, &path).await?;
@@ -140,7 +148,7 @@ where
         return buffered_browser_audio(
             &playback_media,
             plan.source,
-            plan.format,
+            plan.playback,
             plan.absolute_start_ms,
             plan.end_ms,
             headers,
@@ -151,7 +159,7 @@ where
     streaming_browser_audio(
         playback_media,
         plan.source,
-        plan.format,
+        plan.playback,
         plan.absolute_start_ms,
         plan.end_ms,
     )
@@ -161,7 +169,7 @@ where
 async fn buffered_browser_audio(
     playback_media: &impl PlaybackMedia,
     source: PlaybackSource,
-    playback_format: BrowserPlaybackFormat,
+    playback: BrowserPlaybackSettings,
     absolute_start_ms: i64,
     end_ms: Option<i64>,
     headers: HeaderMap,
@@ -170,7 +178,7 @@ async fn buffered_browser_audio(
     let rendered = playback_media
         .transcode_browser_audio(BrowserAudioRequest {
             path: PathBuf::from(source.path),
-            format: playback_format,
+            playback,
             start_ms: absolute_start_ms,
             end_ms,
         })
@@ -189,7 +197,7 @@ async fn buffered_browser_audio(
 async fn streaming_browser_audio<M>(
     playback_media: M,
     source: PlaybackSource,
-    playback_format: BrowserPlaybackFormat,
+    playback: BrowserPlaybackSettings,
     absolute_start_ms: i64,
     end_ms: Option<i64>,
 ) -> ApiResult<Response>
@@ -202,13 +210,13 @@ where
     let output_fd = writer.into_raw_fd();
     let input_path = PathBuf::from(source.path.clone());
     let title = source.title.clone();
-    let format_info = playback_media.browser_audio_format(playback_format);
+    let format_info = playback_media.browser_audio_format(playback.clone());
     tokio::spawn(async move {
         if let Err(err) = playback_media
             .transcode_browser_audio_to_fd(
                 BrowserAudioRequest {
                     path: input_path.clone(),
-                    format: playback_format,
+                    playback,
                     start_ms: absolute_start_ms,
                     end_ms,
                 },

--- a/crates/server/src/services/playback.rs
+++ b/crates/server/src/services/playback.rs
@@ -66,11 +66,12 @@ pub async fn stream_track_hls_file_response(
     let path = hls_cache::hls_file_path(&cache_dir, &file)?;
     hls_cache::ensure_hls_generation(state.services.playback_media.clone(), &source, &cache_dir)
         .await?;
-    hls_cache::wait_for_hls_file(&path, hls_cache::hls_file_timeout(&file)).await?;
     let mime = hls_file_mime(&file)?;
     if file == HLS_PLAYLIST_FILE {
+        hls_cache::wait_for_hls_playlist_start(&cache_dir, &path).await?;
         return hls_playlist_response(&path).await;
     }
+    hls_cache::wait_for_hls_file(&path, hls_cache::hls_file_timeout(&file)).await?;
     let mut response = ranged_file_response(&path, mime, None, &headers, false).await?;
     response
         .headers_mut()

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -169,34 +169,107 @@ pub struct ScanJobStatus {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BrowserPlaybackFormat {
-    #[serde(rename = "opus_256k")]
-    Opus256k,
-    #[serde(rename = "flac_48k")]
-    Flac48k,
+    #[serde(rename = "opus")]
+    Opus,
+    #[serde(rename = "flac")]
+    Flac,
+}
+
+pub const DEFAULT_BROWSER_PLAYBACK_OPUS_BITRATE: i64 = 256_000;
+pub const BROWSER_PLAYBACK_OPUS_BITRATE_OPTIONS: [i64; 7] =
+    [64_000, 96_000, 128_000, 160_000, 192_000, 256_000, 320_000];
+pub const MIN_BROWSER_PLAYBACK_OPUS_BITRATE: i64 = 64_000;
+pub const MAX_BROWSER_PLAYBACK_OPUS_BITRATE: i64 = 320_000;
+pub const DEFAULT_BROWSER_PLAYBACK_FLAC_SAMPLE_RATE: i64 = 48_000;
+pub const BROWSER_PLAYBACK_FLAC_SAMPLE_RATE_OPTIONS: [i64; 6] =
+    [44_100, 48_000, 88_200, 96_000, 176_400, 192_000];
+pub const MIN_BROWSER_PLAYBACK_FLAC_SAMPLE_RATE: i64 = 44_100;
+pub const MAX_BROWSER_PLAYBACK_FLAC_SAMPLE_RATE: i64 = 192_000;
+
+pub fn normalize_browser_playback_opus_bitrate(value: i64) -> i64 {
+    nearest_browser_playback_option(
+        value,
+        &BROWSER_PLAYBACK_OPUS_BITRATE_OPTIONS,
+        DEFAULT_BROWSER_PLAYBACK_OPUS_BITRATE,
+    )
+}
+
+pub fn normalize_browser_playback_flac_sample_rate(value: i64) -> i64 {
+    nearest_browser_playback_option(
+        value,
+        &BROWSER_PLAYBACK_FLAC_SAMPLE_RATE_OPTIONS,
+        DEFAULT_BROWSER_PLAYBACK_FLAC_SAMPLE_RATE,
+    )
+}
+
+fn nearest_browser_playback_option(value: i64, options: &[i64], default: i64) -> i64 {
+    options
+        .iter()
+        .copied()
+        .min_by_key(|option| (i128::from(value) - i128::from(*option)).abs())
+        .unwrap_or(default)
 }
 
 impl Default for BrowserPlaybackFormat {
     fn default() -> Self {
-        Self::Opus256k
+        Self::Opus
+    }
+}
+
+fn default_browser_playback_opus_bitrate() -> i64 {
+    DEFAULT_BROWSER_PLAYBACK_OPUS_BITRATE
+}
+
+fn default_browser_playback_flac_sample_rate() -> i64 {
+    DEFAULT_BROWSER_PLAYBACK_FLAC_SAMPLE_RATE
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct BrowserPlaybackSettings {
+    #[serde(default)]
+    pub format: BrowserPlaybackFormat,
+    #[serde(default = "default_browser_playback_opus_bitrate")]
+    pub opus_bitrate: i64,
+    #[serde(default = "default_browser_playback_flac_sample_rate")]
+    pub flac_sample_rate: i64,
+}
+
+impl Default for BrowserPlaybackSettings {
+    fn default() -> Self {
+        Self {
+            format: BrowserPlaybackFormat::default(),
+            opus_bitrate: DEFAULT_BROWSER_PLAYBACK_OPUS_BITRATE,
+            flac_sample_rate: DEFAULT_BROWSER_PLAYBACK_FLAC_SAMPLE_RATE,
+        }
+    }
+}
+
+impl BrowserPlaybackSettings {
+    pub fn normalized(mut self) -> Self {
+        self.opus_bitrate = normalize_browser_playback_opus_bitrate(self.opus_bitrate);
+        self.flac_sample_rate = normalize_browser_playback_flac_sample_rate(self.flac_sample_rate);
+        self
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppSettings {
-    pub browser_playback_format: BrowserPlaybackFormat,
+    #[serde(default)]
+    pub browser_playback: BrowserPlaybackSettings,
 }
 
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
-            browser_playback_format: BrowserPlaybackFormat::default(),
+            browser_playback: BrowserPlaybackSettings::default(),
         }
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateAppSettingsRequest {
-    pub browser_playback_format: BrowserPlaybackFormat,
+    #[serde(default)]
+    pub browser_playback: BrowserPlaybackSettings,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/web/dist/style.css
+++ b/crates/web/dist/style.css
@@ -110,6 +110,7 @@ button:disabled {
 .shell-search input,
 .toolbar input,
 .settings input,
+.settings select,
 .settings textarea,
 .pagination input {
   min-width: 0;
@@ -485,6 +486,16 @@ button:disabled {
 
 .checkbox-row input {
   width: auto;
+}
+
+.setting-field {
+  display: grid;
+  gap: 6px;
+  color: #4b5563;
+}
+
+.setting-field span {
+  font-size: 0.9rem;
 }
 
 .settings textarea {

--- a/crates/web/src/api.rs
+++ b/crates/web/src/api.rs
@@ -89,25 +89,25 @@ pub(crate) fn spawn_text_status<T>(
 }
 
 pub(crate) fn spawn_settings_load(
-    set_browser_playback_format: WriteSignal<easy_musiclib_shared::BrowserPlaybackFormat>,
+    set_browser_playback: WriteSignal<easy_musiclib_shared::BrowserPlaybackSettings>,
     set_settings_status: WriteSignal<String>,
 ) {
     spawn_result! {
         api_get::<easy_musiclib_shared::AppSettings>("/api/settings"),
         Ok(settings) => {
-            set_browser_playback_format.set(settings.browser_playback_format);
+            set_browser_playback.set(settings.browser_playback);
             set_settings_status.set(String::from("Settings loaded"));
         },
         Err(err) => { set_settings_status.set(err); },
     };
 }
 
-pub(crate) fn spawn_settings_format_load(
-    set_browser_playback_format: WriteSignal<easy_musiclib_shared::BrowserPlaybackFormat>,
+pub(crate) fn spawn_playback_settings_load(
+    set_browser_playback: WriteSignal<easy_musiclib_shared::BrowserPlaybackSettings>,
 ) {
     spawn_async! {
         if let Ok(settings) = api_get::<easy_musiclib_shared::AppSettings>("/api/settings").await {
-            set_browser_playback_format.set(settings.browser_playback_format);
+            set_browser_playback.set(settings.browser_playback);
         }
     };
 }

--- a/crates/web/src/hls_prefetch.rs
+++ b/crates/web/src/hls_prefetch.rs
@@ -1,6 +1,8 @@
 use crate::api::api_get;
 use easy_musiclib_macros::spawn_async;
-use easy_musiclib_shared::{AppSettings, BrowserPlaybackFormat, TrackSummary};
+use easy_musiclib_shared::{
+    AppSettings, BrowserPlaybackFormat, BrowserPlaybackSettings, TrackSummary,
+};
 use gloo_net::http::Request;
 use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
@@ -20,9 +22,9 @@ pub(crate) fn hls_url(track_id: i64) -> String {
 
 pub(crate) fn audio_supports_flac_hls(
     audio: &web_sys::HtmlAudioElement,
-    format: BrowserPlaybackFormat,
+    playback: BrowserPlaybackSettings,
 ) -> bool {
-    if format != BrowserPlaybackFormat::Flac48k {
+    if playback.format != BrowserPlaybackFormat::Flac {
         return false;
     }
     audio
@@ -46,7 +48,7 @@ pub(crate) fn spawn_hls_page_prefetch(tracks: Vec<TrackSummary>) {
         if !is_active_prefetch_epoch(epoch) {
             return;
         }
-        if !browser_supports_flac_hls(settings.browser_playback_format) {
+        if !browser_supports_flac_hls(settings.browser_playback) {
             return;
         }
         prefetch_hls_track_ids(hls_page_prefetch_track_ids(&tracks), epoch);
@@ -65,7 +67,7 @@ pub(crate) fn prefetch_hls_playlist_tracks(
     );
 }
 
-fn browser_supports_flac_hls(format: BrowserPlaybackFormat) -> bool {
+fn browser_supports_flac_hls(playback: BrowserPlaybackSettings) -> bool {
     let Some(window) = web_sys::window() else {
         return false;
     };
@@ -78,7 +80,7 @@ fn browser_supports_flac_hls(format: BrowserPlaybackFormat) -> bool {
     let Ok(audio) = element.dyn_into::<web_sys::HtmlAudioElement>() else {
         return false;
     };
-    audio_supports_flac_hls(&audio, format)
+    audio_supports_flac_hls(&audio, playback)
 }
 
 fn next_prefetch_epoch() -> u64 {

--- a/crates/web/src/pages.rs
+++ b/crates/web/src/pages.rs
@@ -12,9 +12,10 @@ use crate::util::{album_counts, album_date, paged_status, pretty_json};
 use easy_musiclib_macros::{match_any_view, spawn_result};
 use easy_musiclib_shared::{
     AlbumDetail, AlbumSummary, AliasCsvImportRequest, AppSettings, ArtistDetail, ArtistSummary,
-    BrowserPlaybackFormat, CreateArtistRequest, EventDetail, EventSummary, HlsCacheClearResponse,
-    MergeArtistsRequest, RelationGraph, ScanJobRequest, ScanJobStatus, TrackSummary,
-    UpdateAppSettingsRequest,
+    BROWSER_PLAYBACK_FLAC_SAMPLE_RATE_OPTIONS, BROWSER_PLAYBACK_OPUS_BITRATE_OPTIONS,
+    BrowserPlaybackFormat, BrowserPlaybackSettings, CreateArtistRequest, EventDetail, EventSummary,
+    HlsCacheClearResponse, MergeArtistsRequest, RelationGraph, ScanJobRequest, ScanJobStatus,
+    TrackSummary, UpdateAppSettingsRequest,
 };
 use leptos::prelude::*;
 
@@ -613,11 +614,10 @@ pub(crate) fn SettingsPage() -> impl IntoView {
     let (by_name, set_by_name) = signal(false);
     let (alias_csv, set_alias_csv) = signal(String::new());
     let (settings_status, set_settings_status) = signal(String::new());
-    let (browser_playback_format, set_browser_playback_format) =
-        signal(BrowserPlaybackFormat::default());
+    let (browser_playback, set_browser_playback) = signal(BrowserPlaybackSettings::default());
 
     Effect::new(move |_| {
-        spawn_settings_load(set_browser_playback_format, set_settings_status);
+        spawn_settings_load(set_browser_playback, set_settings_status);
     });
 
     let start_scan = move |_| {
@@ -678,17 +678,36 @@ pub(crate) fn SettingsPage() -> impl IntoView {
         );
     };
 
-    let save_playback = move |format: BrowserPlaybackFormat| {
-        set_browser_playback_format.set(format);
+    let save_playback = Callback::new(move |playback: BrowserPlaybackSettings| {
+        let playback = playback.normalized();
+        set_browser_playback.set(playback);
         set_settings_status.set(String::from("Saving playback"));
         let req = UpdateAppSettingsRequest {
-            browser_playback_format: format,
+            browser_playback: playback,
         };
         spawn_text_status(
             async move { api_patch_json::<AppSettings, _>("/api/settings", &req).await },
             set_settings_status,
             "Playback saved",
         );
+    });
+
+    let save_playback_format = move |format: BrowserPlaybackFormat| {
+        let mut playback = browser_playback.get_untracked();
+        playback.format = format;
+        save_playback.run(playback);
+    };
+
+    let save_opus_bitrate = move |value: String| {
+        let mut playback = browser_playback.get_untracked();
+        playback.opus_bitrate = parse_i64_or(&value, playback.opus_bitrate);
+        save_playback.run(playback);
+    };
+
+    let save_flac_sample_rate = move |value: String| {
+        let mut playback = browser_playback.get_untracked();
+        playback.flac_sample_rate = parse_i64_or(&value, playback.flac_sample_rate);
+        save_playback.run(playback);
     };
 
     let clear_hls_cache = move |_| {
@@ -718,19 +737,55 @@ pub(crate) fn SettingsPage() -> impl IntoView {
                         <input
                             type="radio"
                             name="browser-playback-format"
-                            prop:checked=move || browser_playback_format.get() == BrowserPlaybackFormat::Opus256k
-                            on:change=move |_| save_playback(BrowserPlaybackFormat::Opus256k)
+                            prop:checked=move || browser_playback.get().format == BrowserPlaybackFormat::Opus
+                            on:change=move |_| save_playback_format(BrowserPlaybackFormat::Opus)
                         />
-                        "Opus 256k"
+                        "Opus"
                     </label>
                     <label class="checkbox-row">
                         <input
                             type="radio"
                             name="browser-playback-format"
-                            prop:checked=move || browser_playback_format.get() == BrowserPlaybackFormat::Flac48k
-                            on:change=move |_| save_playback(BrowserPlaybackFormat::Flac48k)
+                            prop:checked=move || browser_playback.get().format == BrowserPlaybackFormat::Flac
+                            on:change=move |_| save_playback_format(BrowserPlaybackFormat::Flac)
                         />
-                        "FLAC 48kHz"
+                        "FLAC"
+                    </label>
+                </div>
+                <div class="settings-grid">
+                    <label class="setting-field">
+                        <span>"Opus bitrate (kbps)"</span>
+                        <select
+                            prop:value=move || browser_playback.get().opus_bitrate.to_string()
+                            on:change=move |ev| save_opus_bitrate(event_target_value(&ev))
+                        >
+                            <For
+                                each=move || BROWSER_PLAYBACK_OPUS_BITRATE_OPTIONS
+                                key=|bitrate| *bitrate
+                                children=move |bitrate| view! {
+                                    <option value=bitrate.to_string()>
+                                        {format!("{} kbps", bitrate / 1000)}
+                                    </option>
+                                }
+                            />
+                        </select>
+                    </label>
+                    <label class="setting-field">
+                        <span>"FLAC sample rate (Hz)"</span>
+                        <select
+                            prop:value=move || browser_playback.get().flac_sample_rate.to_string()
+                            on:change=move |ev| save_flac_sample_rate(event_target_value(&ev))
+                        >
+                            <For
+                                each=move || BROWSER_PLAYBACK_FLAC_SAMPLE_RATE_OPTIONS
+                                key=|sample_rate| *sample_rate
+                                children=move |sample_rate| view! {
+                                    <option value=sample_rate.to_string()>
+                                        {format_sample_rate(sample_rate)}
+                                    </option>
+                                }
+                            />
+                        </select>
                     </label>
                 </div>
                 <div class="button-row">
@@ -792,5 +847,17 @@ pub(crate) fn SettingsPage() -> impl IntoView {
                 <pre>{settings_status}</pre>
             </section>
         </section>
+    }
+}
+
+fn parse_i64_or(value: &str, fallback: i64) -> i64 {
+    value.trim().parse::<i64>().unwrap_or(fallback)
+}
+
+fn format_sample_rate(sample_rate: i64) -> String {
+    if sample_rate % 1000 == 0 {
+        format!("{} kHz", sample_rate / 1000)
+    } else {
+        format!("{:.1} kHz", sample_rate as f64 / 1000.0)
     }
 }

--- a/crates/web/src/player.rs
+++ b/crates/web/src/player.rs
@@ -21,6 +21,15 @@ use std::rc::Rc;
 use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 use wasm_bindgen_futures::JsFuture;
 
+const HLS_START_DRIFT_TOLERANCE_SECONDS: f64 = 1.0;
+
+#[derive(Clone)]
+struct PendingHlsStart {
+    url: String,
+    position: f64,
+    autoplay: bool,
+}
+
 #[component]
 pub(crate) fn Player() -> impl IntoView {
     let ctx = expect_context::<AppContext>();
@@ -32,7 +41,7 @@ pub(crate) fn Player() -> impl IntoView {
     let (duration, set_duration) = signal(0.0_f64);
     let (stream_start_time, set_stream_start_time) = signal(0.0_f64);
     let (hls_playback, set_hls_playback) = signal(false);
-    let (pending_hls_seek, set_pending_hls_seek) = signal(None::<f64>);
+    let (pending_hls_start, set_pending_hls_start) = signal(None::<PendingHlsStart>);
     let (browser_playback_format, set_browser_playback_format) =
         signal(BrowserPlaybackFormat::default());
     let (playback_mode, set_playback_mode) = signal(String::from("Idle"));
@@ -171,13 +180,18 @@ pub(crate) fn Player() -> impl IntoView {
                 set_stream_start_time.set(0.0);
                 set_display_position(position);
                 if same_src {
-                    set_pending_hls_seek.set(None);
+                    set_pending_hls_start.set(None);
                     audio.set_current_time(position);
                 } else {
                     let _ = audio.pause();
                     audio.set_src(&url);
-                    set_pending_hls_seek.set(Some(position));
+                    set_pending_hls_start.set(Some(PendingHlsStart {
+                        url,
+                        position,
+                        autoplay,
+                    }));
                     audio.load();
+                    audio.set_current_time(position);
                 }
                 if autoplay {
                     match audio.play() {
@@ -197,7 +211,7 @@ pub(crate) fn Player() -> impl IntoView {
                 return;
             }
 
-            set_pending_hls_seek.set(None);
+            set_pending_hls_start.set(None);
             set_hls_playback.set(false);
             set_playback_mode.set(stream_playback_mode(
                 playback_format,
@@ -226,6 +240,32 @@ pub(crate) fn Player() -> impl IntoView {
             }
         }
     });
+
+    let apply_pending_hls_start = move |confirm_playback: bool| {
+        let Some(pending) = pending_hls_start.get_untracked() else {
+            return;
+        };
+        let Some(audio) = audio_ref.get() else {
+            return;
+        };
+        let current_src = audio.current_src();
+        if !current_src.is_empty() && !current_src.ends_with(&pending.url) {
+            set_pending_hls_start.set(None);
+            return;
+        }
+
+        let current = audio.current_time();
+        if hls_start_needs_seek(current, pending.position) {
+            audio.set_current_time(pending.position);
+            return;
+        }
+        if audio.seeking() {
+            return;
+        }
+        if !pending.autoplay || confirm_playback {
+            set_pending_hls_start.set(None);
+        }
+    };
 
     let media_seek_to = start_stream_at.clone();
     let media_seek_by = start_stream_at.clone();
@@ -302,6 +342,10 @@ pub(crate) fn Player() -> impl IntoView {
             return;
         }
         if audio.paused() {
+            if let Some(mut pending) = pending_hls_start.get_untracked() {
+                pending.autoplay = true;
+                set_pending_hls_start.set(Some(pending));
+            }
             match audio.play() {
                 Ok(promise) => {
                     let set_status = ctx.set_status;
@@ -455,6 +499,7 @@ pub(crate) fn Player() -> impl IntoView {
                 set_playing.set(true);
                 set_active_line.set(-2);
             }
+            on:playing=move |_| apply_pending_hls_start(false)
             on:pause=move |_| {
                 set_playing.set(false);
                 if let Some(track) = ctx.current_track.get_untracked() {
@@ -462,15 +507,15 @@ pub(crate) fn Player() -> impl IntoView {
                 }
             }
             on:loadedmetadata=move |_| {
-                if let Some(position) = pending_hls_seek.get_untracked() {
-                    if let Some(audio) = audio_ref.get() {
-                        audio.set_current_time(position);
-                    }
-                    set_pending_hls_seek.set(None);
-                }
+                apply_pending_hls_start(false);
                 update_audio_progress();
             }
-            on:timeupdate=move |_| update_audio_progress()
+            on:canplay=move |_| apply_pending_hls_start(false)
+            on:seeked=move |_| apply_pending_hls_start(false)
+            on:timeupdate=move |_| {
+                apply_pending_hls_start(true);
+                update_audio_progress();
+            }
             on:error=move |_| {
                 if let Some(audio) = audio_ref.get() {
                     ctx.set_status.set(audio_error_text(&audio));
@@ -612,6 +657,14 @@ fn stream_url(track_id: i64, start_ms: i64) -> String {
         url.push_str("&buffered=true");
     }
     url
+}
+
+fn hls_start_needs_seek(current: f64, target: f64) -> bool {
+    if !current.is_finite() || !target.is_finite() {
+        return false;
+    }
+    current > target + HLS_START_DRIFT_TOLERANCE_SECONDS
+        || current + HLS_START_DRIFT_TOLERANCE_SECONDS < target
 }
 
 fn stream_playback_mode(format: BrowserPlaybackFormat, buffered: bool) -> String {

--- a/crates/web/src/player.rs
+++ b/crates/web/src/player.rs
@@ -1,4 +1,4 @@
-use crate::api::{api_get, api_patch_json, spawn_settings_format_load};
+use crate::api::{api_get, api_patch_json, spawn_playback_settings_load};
 use crate::app::{AppContext, PlayRequest};
 use crate::hls_prefetch::{audio_supports_flac_hls, hls_url, prefetch_hls_playlist_tracks};
 use crate::lyrics::{
@@ -14,7 +14,8 @@ use crate::ui::{ArtistInlineLinks, EntityLink};
 use crate::util::{format_time, progress_value};
 use easy_musiclib_macros::{js_get, match_any_view, spawn_async, spawn_result};
 use easy_musiclib_shared::{
-    BrowserPlaybackFormat, LikePatch, LyricsCandidate, TrackDetail, TrackSummary,
+    BrowserPlaybackFormat, BrowserPlaybackSettings, LikePatch, LyricsCandidate, TrackDetail,
+    TrackSummary,
 };
 use leptos::prelude::*;
 use std::rc::Rc;
@@ -42,8 +43,7 @@ pub(crate) fn Player() -> impl IntoView {
     let (stream_start_time, set_stream_start_time) = signal(0.0_f64);
     let (hls_playback, set_hls_playback) = signal(false);
     let (pending_hls_start, set_pending_hls_start) = signal(None::<PendingHlsStart>);
-    let (browser_playback_format, set_browser_playback_format) =
-        signal(BrowserPlaybackFormat::default());
+    let (browser_playback, set_browser_playback) = signal(BrowserPlaybackSettings::default());
     let (playback_mode, set_playback_mode) = signal(String::from("Idle"));
     let (seek_value, set_seek_value) = signal(0_i64);
     let (seeking, set_seeking) = signal(false);
@@ -68,14 +68,14 @@ pub(crate) fn Player() -> impl IntoView {
     };
 
     Effect::new(move |_| {
-        spawn_settings_format_load(set_browser_playback_format);
+        spawn_playback_settings_load(set_browser_playback);
     });
 
     Effect::new(move |_| {
         let Some(audio) = audio_ref.get() else {
             return;
         };
-        if !audio_supports_flac_hls(&audio, browser_playback_format.get()) {
+        if !audio_supports_flac_hls(&audio, browser_playback.get()) {
             return;
         }
         if !playing.get() {
@@ -171,12 +171,12 @@ pub(crate) fn Player() -> impl IntoView {
         };
         let position = clamp_position(position);
         if let Some(audio) = audio_ref.get() {
-            let playback_format = browser_playback_format.get_untracked();
-            if audio_supports_flac_hls(&audio, playback_format) {
+            let playback = browser_playback.get_untracked();
+            if audio_supports_flac_hls(&audio, playback) {
                 let url = hls_url(track.id);
                 let same_src = hls_playback.get_untracked() && audio.current_src().ends_with(&url);
                 set_hls_playback.set(true);
-                set_playback_mode.set(String::from("FLAC HLS"));
+                set_playback_mode.set(format!("FLAC HLS {}Hz", playback.flac_sample_rate));
                 set_stream_start_time.set(0.0);
                 set_display_position(position);
                 if same_src {
@@ -214,7 +214,7 @@ pub(crate) fn Player() -> impl IntoView {
             set_pending_hls_start.set(None);
             set_hls_playback.set(false);
             set_playback_mode.set(stream_playback_mode(
-                playback_format,
+                playback,
                 needs_buffered_audio_response(),
             ));
             set_stream_start_time.set(position);
@@ -667,11 +667,15 @@ fn hls_start_needs_seek(current: f64, target: f64) -> bool {
         || current + HLS_START_DRIFT_TOLERANCE_SECONDS < target
 }
 
-fn stream_playback_mode(format: BrowserPlaybackFormat, buffered: bool) -> String {
+fn stream_playback_mode(playback: BrowserPlaybackSettings, buffered: bool) -> String {
     let transport = if buffered { "buffered" } else { "direct" };
-    match format {
-        BrowserPlaybackFormat::Opus256k => format!("{transport} Opus"),
-        BrowserPlaybackFormat::Flac48k => format!("{transport} FLAC"),
+    match playback.format {
+        BrowserPlaybackFormat::Opus => {
+            format!("{transport} Opus {}k", playback.opus_bitrate / 1000)
+        }
+        BrowserPlaybackFormat::Flac => {
+            format!("{transport} FLAC {}Hz", playback.flac_sample_rate)
+        }
     }
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -69,7 +69,7 @@ GET /api/tracks/{id_or_uuid}/download
 
 `stream` returns browser-playback audio in the configured playback format. `start_ms` is optional and defaults to `0`; when present, the stream starts at that millisecond offset relative to the track. For CUE tracks, the offset is relative to the CUE track start and is clamped to the CUE track's duration. Streaming is sequential by default and returns `Accept-Ranges: none`; clients should restart the stream with a new `start_ms` to seek. Add `buffered=true` when the client needs a `Content-Length`/HTTP Range compatible media response, such as Safari or iOS WebView.
 
-`hls/{file}` returns generated FLAC 48 kHz fMP4 HLS files for playable tracks. Valid file names are `playlist.m3u8`, `init.mp4`, and segment files matching `segment_00000.m4s`. Requesting the playlist starts HLS generation if the cache is missing; files may briefly return `404` with `HLS file is not ready` while generation is still in progress. The playlist is returned as `application/vnd.apple.mpegurl`; init and segment files are returned as `audio/mp4` and support HTTP Range.
+`hls/{file}` returns generated FLAC fMP4 HLS files for playable tracks at the configured FLAC sample rate. Valid file names are `playlist.m3u8`, `init.mp4`, and segment files matching `segment_00000.m4s`. Requesting the playlist starts HLS generation if the cache is missing; files may briefly return `404` with `HLS file is not ready` while generation is still in progress. The playlist is returned as `application/vnd.apple.mpegurl`; init and segment files are returned as `audio/mp4` and support HTTP Range.
 
 `download` returns the original/native track output. Ordinary file downloads support HTTP Range. CUE tracks are rendered as independent audio responses and do not expose the whole-album source file as a frontend URL.
 
@@ -77,19 +77,23 @@ GET /api/tracks/{id_or_uuid}/download
 
 ```text
 GET   /api/settings
-PATCH /api/settings { "browser_playback_format": "opus_256k" }
-PATCH /api/settings { "browser_playback_format": "flac_48k" }
+PATCH /api/settings { "browser_playback": { "format": "opus", "opus_bitrate": 256000, "flac_sample_rate": 48000 } }
+PATCH /api/settings { "browser_playback": { "format": "flac", "opus_bitrate": 256000, "flac_sample_rate": 48000 } }
 ```
 
 Response:
 
 ```json
 {
-  "browser_playback_format": "opus_256k"
+  "browser_playback": {
+    "format": "opus",
+    "opus_bitrate": 256000,
+    "flac_sample_rate": 48000
+  }
 }
 ```
 
-`browser_playback_format` controls the format used by `/api/tracks/{id_or_uuid}/stream`. Supported values are `opus_256k` and `flac_48k`.
+`browser_playback.format` controls the format used by `/api/tracks/{id_or_uuid}/stream`. Supported values are `opus` and `flac`. `opus_bitrate` is selected from common bitrates in bits per second: `64000`, `96000`, `128000`, `160000`, `192000`, `256000`, `320000`. `flac_sample_rate` is selected from common sample rates in Hz: `44100`, `48000`, `88200`, `96000`, `176400`, `192000`.
 
 ## Lyrics
 


### PR DESCRIPTION
## Summary by Sourcery

Add configurable browser playback settings (format, Opus bitrate, FLAC sample rate) and integrate them across server, media pipeline, HLS generation, and web UI to improve playback quality and startup behavior.

New Features:
- Introduce browser playback settings that include format, Opus bitrate, and FLAC sample rate with normalization and persistence in app settings.
- Allow HLS FLAC generation at the configured sample rate and key HLS cache entries by that rate.
- Add UI controls for selecting Opus bitrate and FLAC sample rate, and display the chosen playback characteristics in the player.

Bug Fixes:
- Ensure HLS responses wait for both playlist and initial media files to be fully written before serving, reducing startup errors and partial reads.
- Reset legacy playback settings in the database once to avoid incompatible stored values with the new playback model.

Enhancements:
- Refine browser FLAC HLS startup by tracking pending starts, tolerating small time drift, and coordinating seeks across media events.
- Generalize media transcoding pipeline to support parameterized Opus bitrate and FLAC sample rates instead of fixed formats.
- Tighten HLS file readiness checks to require non-empty files and extract initial segment references from the playlist for startup validation.
- Improve settings and player UI styling and labels to accommodate the richer playback configuration.

Documentation:
- Update API documentation for settings and HLS endpoints to describe the new browser playback settings structure and supported values.